### PR TITLE
Add an EC2 instance

### DIFF
--- a/bin/sandbox-ec2.ts
+++ b/bin/sandbox-ec2.ts
@@ -7,9 +7,9 @@ import { Aspects } from "aws-cdk-lib";
 
 const app = new cdk.App();
 Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
-const stack = new SandboxEc2(app, "StartCDKStack", {});
+const stack = new SandboxEc2(app, "SandboxEc2Stack", {});
 
 // 必要に応じて作成するリソース全体に共通のタグを追加
-// cdk.Tags.of(app).add("project", "StartCDKProject");
+// cdk.Tags.of(app).add("project", "SandboxEc2");
 
 stack.addCdkNagSuppressions();

--- a/lib/constructs/EC2/index.ts
+++ b/lib/constructs/EC2/index.ts
@@ -1,0 +1,87 @@
+import { Construct } from "constructs";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import { StackProps } from "aws-cdk-lib";
+import * as iam from "aws-cdk-lib/aws-iam";
+import { NagSuppressions } from "cdk-nag";
+import * as cdk from "aws-cdk-lib";
+
+/**
+ * ECSのプロパティ
+ */
+export interface EC2Props extends StackProps {
+  /**
+   * ECSクラスタを作成するVPC
+   */
+  vpc: ec2.Vpc;
+}
+
+/**
+ * VPCとVPCエンドポイントに関するリソースを定義する
+ */
+export class EC2 extends Construct {
+  constructor(scope: Construct, id: string, props: EC2Props) {
+    super(scope, id);
+    // IAM Role for EC2 instance to allow SSM access
+    const role = new iam.Role(this, "SSMRole", {
+      assumedBy: new iam.ServicePrincipal("ec2.amazonaws.com"),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "AmazonSSMManagedInstanceCore",
+        ),
+      ],
+    });
+
+    // Security Group for EC2 instance
+    const securityGroup = new ec2.SecurityGroup(this, "EC2SecurityGroup", {
+      vpc: props.vpc,
+      description: "Allow SSH and SSM access",
+      allowAllOutbound: true,
+    });
+
+    // Amazon Linux 2 EC2 instance
+    new ec2.Instance(this, "Instance", {
+      vpc: props.vpc,
+      instanceType: new ec2.InstanceType("t3.micro"),
+      machineImage: ec2.MachineImage.latestAmazonLinux2({
+        cpuType: ec2.AmazonLinuxCpuType.X86_64,
+        edition: ec2.AmazonLinuxEdition.STANDARD,
+        kernel: ec2.AmazonLinux2Kernel.DEFAULT,
+        storage: ec2.AmazonLinuxStorage.GENERAL_PURPOSE,
+      }),
+      detailedMonitoring: true,
+      role: role,
+      securityGroup: securityGroup,
+      blockDevices: [
+        {
+          deviceName: "/dev/sda1",
+          volume: ec2.BlockDeviceVolume.ebs(8, {
+            encrypted: true,
+          }),
+        },
+      ],
+    });
+  }
+  public addCdkNagSuppressions(parentStack: cdk.Stack) {
+    NagSuppressions.addResourceSuppressionsByPath(
+      parentStack,
+      "/SandboxEc2Stack/EC2/Instance/Resource",
+      [
+        {
+          id: "AwsSolutions-EC29",
+          reason:
+            "Currently this project is under development and the termination protection is not enabled.",
+        },
+      ],
+    );
+    NagSuppressions.addResourceSuppressionsByPath(
+      parentStack,
+      "/SandboxEc2Stack/EC2/SSMRole/Resource",
+      [
+        {
+          id: "AwsSolutions-IAM4",
+          reason: "We should research his error later.",
+        },
+      ],
+    );
+  }
+}

--- a/lib/constructs/Network/index.ts
+++ b/lib/constructs/Network/index.ts
@@ -18,7 +18,7 @@ export class Network extends Construct {
     // VPCを作成
     this.vpc = new ec2.Vpc(this, "Vpc", {
       natGateways: 0,
-      createInternetGateway: false,
+      createInternetGateway: true,
       maxAzs: 1,
     });
 

--- a/lib/sandbox-ec2.ts
+++ b/lib/sandbox-ec2.ts
@@ -1,21 +1,24 @@
 import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 import { Network } from "./constructs/Network";
+import { EC2 } from "./constructs/EC2";
 
 /**
  * スタック
  */
 export class SandboxEc2 extends cdk.Stack {
+  private ec2: EC2;
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
 
-    new Network(this, "Network");
+    const network = new Network(this, "Network");
+    this.ec2 = new EC2(this, "EC2", { vpc: network.vpc });
   }
 
   /**
    * NAGのチェックを抑制する
    */
   public addCdkNagSuppressions() {
-    // 必要に応じてNag suppressionsを追加
+    this.ec2.addCdkNagSuppressions(this);
   }
 }


### PR DESCRIPTION
This pull request introduces a new `EC2` construct and integrates it with the existing `Network` construct. The primary changes involve defining resources for EC2 instances and updating the network configuration to support these instances.

### EC2 Construct Addition:

* [`lib/constructs/EC2/index.ts`](diffhunk://#diff-36d0289733fee7b7d4fa10469067850758513caf48f5ccf259b54ea5ca80ef23R1-R87): Added a new `EC2` construct that includes an IAM role for SSM access, a security group, and an Amazon Linux 2 EC2 instance. This construct also includes methods for adding CDK Nag suppressions.

### Network Configuration Update:

* [`lib/constructs/Network/index.ts`](diffhunk://#diff-79de2ab62274adbee4f0610c422167d5cb20297dc855c2e9f53ca2b537ec587aL21-R21): Modified the `Network` construct to create an internet gateway, enabling internet access for the VPC.

### Integration with Sandbox Stack:

* [`lib/sandbox-ec2.ts`](diffhunk://#diff-0027eb7e0fad92cb59fe80673d549d7ff5c740ee37011efee55eb29c396130e0R4-R22): Updated the `SandboxEc2` stack to instantiate the new `EC2` construct and link it with the `Network` construct. Also, updated the method to add CDK Nag suppressions to include the new `EC2` resources.