### PR TITLE
ci: merge dependa bot PRs automatically

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -38,3 +38,18 @@ jobs:
   #    pull-requests: write
   #  secrets: inherit
   #  uses: ./.github/workflows/post-cdk-diff.yml
+  # dependabotが作成したPull Requestを自動マージする
+
+  auto-merge-dependabot-pr:
+    needs:
+      - test
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - run: gh pr merge "${GITHUB_HEAD_REF}" --squash --auto
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a new job to the GitHub Actions workflow for automatically merging pull requests created by Dependabot. 

Key change:

* [`.github/workflows/pull_request.yml`](diffhunk://#diff-a0fe23534b616d51ce686d2a1bcd1a78bc75074aef1a2f6ee96c9469991e1a4cR41-R55): Added a new job `auto-merge-dependabot-pr` that triggers when the actor is `dependabot[bot]`, runs on `ubuntu-latest`, and merges the pull request using the GitHub CLI with squash and auto-merge options.